### PR TITLE
register_file: treat x0 as non-writable

### DIFF
--- a/rtl/register_file.vhdl
+++ b/rtl/register_file.vhdl
@@ -55,6 +55,8 @@ begin
 
     if (reset = '1') then
       registers <= (others => (others => '0'));
+    elsif (select_write = "00000") then
+      -- skip writes to x0 to keep it 0
     elsif (rising_edge(clk) and write_enable = '1') then
       registers(to_integer(unsigned(select_write))) <= data_write;
     end if;

--- a/rtl/register_file_tb.vhdl
+++ b/rtl/register_file_tb.vhdl
@@ -152,6 +152,27 @@ begin
       report "data_b must be 64"
       severity error;
 
+    -- Writing to x0 does not change it
+    select_a <= std_logic_vector(to_unsigned(0, select_a'length));
+    select_b <= std_logic_vector(to_unsigned(0, select_a'length));
+    select_write <= std_logic_vector(to_unsigned(0, select_write'length));
+    data_write   <= std_logic_vector(to_unsigned(255, data_write'length));
+    write_enable <= '0';
+
+    clk <= '0';
+    wait for propagation_time;
+    assert data_a = std_logic_vector(to_unsigned(0, data_a'length))
+      report "reading x0: data_a must be 0"
+      severity error;
+
+    write_enable <= '1';
+    clk <= '1';
+    wait for propagation_time;
+    assert data_a = std_logic_vector(to_unsigned(0, data_a'length))
+      report "reading x0 after write: data_a must be 0"
+      severity error;
+
+    -- done
     assert false
       report "test bench for register file is done"
       severity note;


### PR DESCRIPTION
The specification says that x0 is the zero register, i.e. "hardwired zero". Reads from x0 are always 0, writes to x0 are ignored.